### PR TITLE
bug: simple failing test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,6 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+data
+.crunchdao

--- a/tests/accounting/test_simplepnl.py
+++ b/tests/accounting/test_simplepnl.py
@@ -9,6 +9,13 @@ def test_initial_state():
     assert pnl_tracker.pnl_data == [], f"Expected pnl_data=[], got {pnl_tracker.pnl_data}"
 
 
+
+def test_tick_once_for_now():
+    pnl_tracker = Pnl(epsilon=0)
+    pnl_tracker.tick(x=1.0, horizon=1, decision=1)
+    assert(len(pnl_tracker.pending_decisions)==1)
+
+
 def test_tick_once():
     pnl_tracker = Pnl(epsilon=0)
     pnl_tracker.tick(x=1.0, horizon=7, decision=1)
@@ -179,4 +186,3 @@ def test_sequential_resolutions_with_no_decision():
 if __name__ == "__main__":
     import pytest
     pytest.main([__file__])
-


### PR DESCRIPTION
Note that Claude can fix it but it found an error in one of the test:

The error occurs in the test_multiple_decisions_over_time function. The test expects all pending decisions to be resolved by the fourth tick, but one decision remains pending. Let's break down the steps:

First decision: horizon 3, made at index 0
Second decision: horizon 4, made at index 1
First decision resolved at index 3
Test expects second decision to be resolved at index 4

The issue is that the second decision, with a horizon of 4, should not be resolved until index 5 (1 + 4). Our test is incorrect in expecting it to be resolved at index 4.