### PR TITLE
fix: logic PnL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+#.idea
+*.ipynb
+data
+.crunchdao

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml

--- a/.idea/endersgame.iml
+++ b/.idea/endersgame.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="PYTHON_MODULE" version="4">
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="jdk" jdkName="endersgame (2)" jdkType="Python SDK" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,6 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <settings>
-    <option name="USE_PROJECT_PROFILE" value="false" />
-    <version value="1.0" />
-  </settings>
-</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Black">
-    <option name="sdkName" value="endersgame (2)" />
-  </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="endersgame (2)" project-jdk-type="Python SDK" />
-</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/endersgame.iml" filepath="$PROJECT_DIR$/.idea/endersgame.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/endersgame/accounting/pnl.py
+++ b/endersgame/accounting/pnl.py
@@ -1,138 +1,108 @@
-from typing import Dict
+from typing import Dict, List, Tuple
 import numpy as np
+from collections import OrderedDict
 from endersgame import EPSILON
 
 DEFAULT_TRADE_BACKOFF = 1  # The minimum time between non-zero decisions
 
+
 class Pnl:
     """
-    Simple logging of PnL (Profit and Loss) for all decisions made by an attacker.
-
-    - Non-zero decisions are tracked in a list of dictionaries.
-    - Each decision is resolved when the corresponding future value becomes available.
-    - Decisions made within self.backoff data points of the last non-zero decision are ignored.
-
-    """
+Simple logging of PnL (Profit and Loss) for all decisions made by an attacker.
+- Non-zero decisions are tracked in a OrderedDict of dictionaries.
+- Each decision is resolved when the corresponding future value becomes available.
+- Decisions made within self.backoff data points of the last non-zero decision are ignored.
+"""
 
     def __init__(self, epsilon: float = EPSILON, backoff: int = DEFAULT_TRADE_BACKOFF):
-        self.epsilon = epsilon      # Trading cost
-        self.backoff = backoff      # We will not record trades more often than this
+        self.epsilon = epsilon
+        self.backoff = backoff
         self.current_ndx = 0
         self.last_attack_ndx = None
-        self.pending_decisions = []
-        self.pnl_data = []
+        self._pending_decisions: OrderedDict[int, Dict] = OrderedDict()
+        self._pnl_data: OrderedDict[int, Dict] = OrderedDict()
         self.pnl_columns = ['decision_ndx', 'resolution_ndx', 'horizon',
-                            'decision', 'y_decision', 'y_resolution','pnl']
+                            'decision', 'y_decision', 'y_resolution', 'pnl']
 
+    @property
+    def pending_decisions(self) -> List[Dict]:
+        return [{'index': k, **v} for k, v in self._pending_decisions.items()]
+
+    @property
+    def pnl_data(self) -> List[Dict]:
+        return list(self._pnl_data.values())
 
     def tick(self, x: float, horizon: int, decision: float):
         """
-
-            Adds non-zero 'decision' to a queue so it can be judged later
-            And uses revealed ground truth y to evaluate past decisions
-
+        Processes a new data point, potentially making a decision and resolving pending decisions.
         """
-        self._add_decision_to_queue(x=x, horizon=horizon, decision=decision)
-        self._resolve_decisions_on_queue(x=x)
-
-    def reset_pnl(self):
-        """Resets all PnL tracking variables within the accounting property."""
-        self.current_ndx = 0
-        self.last_attack_ndx = None
-        self.pending_decisions.clear()
-        self.pnl_data.clear()
-
-    def _add_decision_to_queue(self, x: float, horizon: int, decision: float):
-        """
-        Store a decision made at the current time step.
-
-        - y:        The last value seen when making the decision
-        - decision: The decision made (positive for up, negative for down).
-        """
-        # Don't record a decision if another decision has recently been made
-        # (We want to cut out machine gun attacks)
-        if (self.last_attack_ndx is not None) and \
-                (self.current_ndx - self.last_attack_ndx) < self.backoff:
-            pass
-        else:
-            # Store the decision and the time it was made
-            if decision != 0:
-                self.pending_decisions.append((self.current_ndx, x, horizon, decision))
-                self.last_attack_ndx = self.current_ndx
-
-        # Increment total observations
+        self._add_decision(x, horizon, decision)
+        self._resolve_decisions(x)
         self.current_ndx += 1
 
-    def _resolve_decisions_on_queue(self, x: float):
+    def _add_decision(self, x: float, horizon: int, decision: float):
         """
-        Resolve pending decisions by calculating PnL when enough time has passed and the future value is available.
-
-        - x: The newly arrived data point (the current value of the sequence).
+        Adds a non-zero decision to the pending decisions dictionary.
         """
-        resolved_decision_indices = []
-        current_ndx = self.current_ndx
+        if decision != 0 and (self.last_attack_ndx is None or
+                              self.current_ndx - self.last_attack_ndx >= self.backoff):
+            self._pending_decisions[self.current_ndx] = {
+                'x': x,
+                'horizon': horizon,
+                'decision': decision
+            }
+            self.last_attack_ndx = self.current_ndx
 
-        for pending_index, (decision_ndx, x_prev, horizon_, decision) in enumerate(self.pending_decisions):
-            # Calculate the number of observations since the decision was made
-            num_observations_since_decision = current_ndx - decision_ndx
-
-            # Resolve the decision if the horizon has been reached
-            if num_observations_since_decision >= horizon_:
-                # Calculate PnL based on the decision direction
-                if decision > 0:
-                    # Long position: Profit when price increases
-                    pnl = x - x_prev - self.epsilon
-                elif decision < 0:
-                    # Short position: Profit when price decreases
-                    pnl = x_prev - x - self.epsilon
-                else:
-                    raise ValueError('A non-zero decision was logged to the queue with zero decision value')
-
-                # Record the PnL data
-                pnl_data = (
-                    decision_ndx,  # Time index when the decision was made
-                    current_ndx,  # Current time index when decision is resolved
-                    horizon_,  # Horizon over which the decision was held
-                    decision,  # Decision made (+ve for buy, -ve for sell)
-                    x_prev,  # Price at decision time
-                    x,  # Current price
-                    pnl  # Calculated profit or loss
-                )
-                # Append the PnL data to the list of resolved decisions
-                self.pnl_data.append(pnl_data)
-                # Mark this decision as resolved
-                resolved_decision_indices.append(pending_index)
-
-        # Remove resolved decisions from the pending list
-        self.pending_decisions = [
-            decision for idx, decision in enumerate(self.pending_decisions)
-            if idx not in resolved_decision_indices
-        ]
-
-
-
-    def get_pnl_tuples(self):
+    def _resolve_decisions(self, x: float):
         """
-          Takes resolved decision tuples and coverts them into a format that is easily consumed as a dataframe
-          pnl_data = (decision_ndx, current_ndx, y_prev, y, decision, pnl )
+        Resolves pending decisions by calculating PnL when the future value is available.
         """
+        resolved_indices = []
+        for decision_ndx, decision_data in self._pending_decisions.items():
+            if self.current_ndx - decision_ndx >= decision_data['horizon']:
+                x_prev = decision_data['x']
+                decision = decision_data['decision']
+                pnl = (x - x_prev if decision > 0 else x_prev - x) - self.epsilon
+                self._pnl_data[decision_ndx] = {
+                    'decision_ndx': decision_ndx,
+                    'resolution_ndx': self.current_ndx,
+                    'horizon': decision_data['horizon'],
+                    'decision': decision,
+                    'y_decision': x_prev,
+                    'y_resolution': x,
+                    'pnl': pnl
+                }
+                resolved_indices.append(decision_ndx)
+
+        for idx in resolved_indices:
+            del self._pending_decisions[idx]
+
+    def reset_pnl(self):
+        """Resets all PnL tracking variables."""
+        self.current_ndx = 0
+        self.last_attack_ndx = None
+        self._pending_decisions.clear()
+        self._pnl_data.clear()
+
+    def get_pnl_tuples(self) -> List[Tuple]:
+        """Returns the list of resolved PnL data tuples."""
+        return [tuple(entry.values()) for entry in self._pnl_data.values()]
+
+    def to_records(self) -> List[Dict]:
+        """Converts PnL data to a list of dictionaries."""
         return self.pnl_data
 
-    def to_records(self) -> [Dict]:
-        records = [dict(zip(self.pnl_columns, pnl_rec)) for pnl_rec in self.pnl_data]
-        return records
-
-    def summary(self):
+    def summary(self) -> Dict:
         """Returns a summary of PnL-related statistics from the resolved decisions."""
-        pnl_values = [entry[-1] for entry in self.pnl_data if entry[-1] is not None]
+        pnl_values = [entry['pnl'] for entry in self.pnl_data]
         total_profit = sum(pnl_values)
         num_resolved = len(pnl_values)
 
         if num_resolved == 0:
             return {
                 "current_ndx": self.current_ndx,
-                "num_resolved_decisions": num_resolved,
-                "total_profit": total_profit,
+                "num_resolved_decisions": 0,
+                "total_profit": 0,
                 "win_loss_ratio": None,
                 "average_profit_per_decision": None,
                 "avg_profit_per_decision_std_ratio": None
@@ -140,10 +110,10 @@ class Pnl:
 
         wins = sum(1 for pnl in pnl_values if pnl > 0)
         losses = sum(1 for pnl in pnl_values if pnl < 0)
-        win_loss_ratio = wins / losses if losses != 0 else float('inf')  # Avoid division by zero
+        win_loss_ratio = wins / losses if losses != 0 else float('inf')
 
         avg_profit_per_decision = total_profit / num_resolved
-        pnl_std = np.std(pnl_values) if num_resolved > 1 else 0  # Handle std for single entry case
+        pnl_std = np.std(pnl_values) if num_resolved > 1 else 0
         standardized_profit = avg_profit_per_decision / pnl_std if pnl_std != 0 else float('inf')
 
         return {
@@ -157,10 +127,8 @@ class Pnl:
             "standardized_profit_per_decision": standardized_profit
         }
 
-    def to_dict(self):
-        """
-        Serializes the state of the PnL object to a dictionary.
-        """
+    def to_dict(self) -> Dict:
+        """Serializes the state of the PnL object to a dictionary."""
         return {
             'epsilon': self.epsilon,
             'backoff': self.backoff,
@@ -170,18 +138,21 @@ class Pnl:
             'pnl_data': self.pnl_data
         }
 
-
     @classmethod
-    def from_dict(cls, state):
-        """
-        Deserializes the state from a dictionary into a new PnL instance.
-        """
+    def from_dict(cls, state: Dict):
+        """Deserializes the state from a dictionary into a new Pnl instance."""
         instance = cls(
-            epsilon=state.get('epsilon',EPSILON),
+            epsilon=state.get('epsilon', EPSILON),
             backoff=state.get('backoff', DEFAULT_TRADE_BACKOFF),
         )
-        instance.current_ndx = state.get('current_ndx',0)
+        instance.current_ndx = state.get('current_ndx', 0)
         instance.last_attack_ndx = state.get('last_attack_ndx')
-        instance.pending_decisions = state.get('pending_decisions',[])
-        instance.pnl_data = state.get('pnl_data',[])
+
+        for decision in state.get('pending_decisions', []):
+            index = decision.pop('index')
+            instance._pending_decisions[index] = decision
+
+        for pnl_entry in state.get('pnl_data', []):
+            instance._pnl_data[pnl_entry['decision_ndx']] = pnl_entry
+
         return instance

--- a/endersgame/attackers/attackerwithpnl.py
+++ b/endersgame/attackers/attackerwithpnl.py
@@ -9,9 +9,9 @@ class AttackerWithPnl(BaseAttacker):
     An attacker that tracks profit and loss (PnL).
     """
 
-    def __init__(self, epsilon: float = EPSILON, backoff:int=DEFAULT_TRADE_BACKOFF):
+    def __init__(self, epsilon: float = EPSILON, backoff: int = DEFAULT_TRADE_BACKOFF):
         super().__init__()
-        self.pnl = Pnl(epsilon=epsilon, backoff=DEFAULT_TRADE_BACKOFF)
+        self.pnl = Pnl(epsilon=epsilon, backoff=backoff)
 
     def tick_and_predict(self, x: float, horizon: int = HORIZON) -> float:
         """
@@ -57,7 +57,10 @@ class AttackerWithPnl(BaseAttacker):
 
     @classmethod
     def from_dict(cls, state: Dict[str, Any]) -> 'AttackerWithPnl':
-        epsilon_with_fallback = state.get('pnl',{'epsilon':EPSILON}).get('epsilon')
-        attacker = cls(epsilon=epsilon_with_fallback)
-        attacker.pnl = Pnl.from_dict(state.get('pnl',{}))
+        pnl_state = state.get('pnl', {})
+        epsilon = pnl_state.get('epsilon', EPSILON)
+        backoff = pnl_state.get('backoff', DEFAULT_TRADE_BACKOFF)
+
+        attacker = cls(epsilon=epsilon, backoff=backoff)
+        attacker.pnl = Pnl.from_dict(pnl_state)
         return attacker

--- a/endersgame/gameconfig.py
+++ b/endersgame/gameconfig.py
@@ -1,4 +1,5 @@
 EPSILON = 0.01     # Trading cost
 HORIZON = 30
+DEFAULT_TRADE_BACKOFF = 100
 
 from endersgame.mixins.historymixin import DEFAULT_HISTORY_LEN # here for backward compat only

--- a/tests/accounting/test_pnl_to_dict.py
+++ b/tests/accounting/test_pnl_to_dict.py
@@ -1,3 +1,4 @@
+import pytest
 from endersgame.accounting.pnl import Pnl
 
 def test_pnl_to_dict():
@@ -19,6 +20,26 @@ def test_pnl_to_dict():
         'pnl_data': pnl.pnl_data
     }
 
+    # Additional checks for the structure of pending_decisions and pnl_data
+    assert isinstance(state['pending_decisions'], list)
+    for decision in state['pending_decisions']:
+        assert isinstance(decision, dict)
+        assert 'index' in decision
+        assert 'x' in decision
+        assert 'horizon' in decision
+        assert 'decision' in decision
+
+    assert isinstance(state['pnl_data'], list)
+    for pnl_entry in state['pnl_data']:
+        assert isinstance(pnl_entry, dict)
+        assert 'decision_ndx' in pnl_entry
+        assert 'resolution_ndx' in pnl_entry
+        assert 'horizon' in pnl_entry
+        assert 'decision' in pnl_entry
+        assert 'y_decision' in pnl_entry
+        assert 'y_resolution' in pnl_entry
+        assert 'pnl' in pnl_entry
+
 def test_pnl_from_dict():
     # Define the serialized state
     state = {
@@ -26,8 +47,20 @@ def test_pnl_from_dict():
         'backoff': 50,
         'current_ndx': 2,
         'last_attack_ndx': 1,
-        'pending_decisions': [(1, 5.0, 10, 1.0)],
-        'pnl_data': [(1, 2, 10, 1.0, 5.0, 6.0, 0.99)]
+        'pending_decisions': [
+            {'index': 1, 'x': 5.0, 'horizon': 10, 'decision': 1.0}
+        ],
+        'pnl_data': [
+            {
+                'decision_ndx': 1,
+                'resolution_ndx': 2,
+                'horizon': 10,
+                'decision': 1.0,
+                'y_decision': 5.0,
+                'y_resolution': 6.0,
+                'pnl': 0.99
+            }
+        ]
     }
 
     # Deserialize into PnL
@@ -38,5 +71,20 @@ def test_pnl_from_dict():
     assert restored_pnl.backoff == 50
     assert restored_pnl.current_ndx == 2
     assert restored_pnl.last_attack_ndx == 1
-    assert restored_pnl.pending_decisions == [(1, 5.0, 10, 1.0)]
-    assert restored_pnl.pnl_data == [(1, 2, 10, 1.0, 5.0, 6.0, 0.99)]
+    assert restored_pnl.pending_decisions == [
+        {'index': 1, 'x': 5.0, 'horizon': 10, 'decision': 1.0}
+    ]
+    assert restored_pnl.pnl_data == [
+        {
+            'decision_ndx': 1,
+            'resolution_ndx': 2,
+            'horizon': 10,
+            'decision': 1.0,
+            'y_decision': 5.0,
+            'y_resolution': 6.0,
+            'pnl': 0.99
+        }
+    ]
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/accounting/test_simplepnl.py
+++ b/tests/accounting/test_simplepnl.py
@@ -1,5 +1,6 @@
+import pytest
 from endersgame.accounting.pnl import Pnl
-
+from endersgame import EPSILON, DEFAULT_TRADE_BACKOFF
 
 def test_initial_state():
     """Test if the initial state of the PnL class is correct."""
@@ -9,174 +10,199 @@ def test_initial_state():
     assert pnl_tracker.pnl_data == [], f"Expected pnl_data=[], got {pnl_tracker.pnl_data}"
 
 
+def test_tick_once_horizon_one():
+    pnl_tracker = Pnl(epsilon=0)
+    pnl_tracker.tick(x=1.0, horizon=1, decision=1)
+    assert len(pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision, got {len(pnl_tracker.pending_decisions)}"
+
+
 def test_tick_once():
     pnl_tracker = Pnl(epsilon=0)
     pnl_tracker.tick(x=1.0, horizon=7, decision=1)
-    assert(len(pnl_tracker.pending_decisions)==1)
+    assert len(pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision, got {len(pnl_tracker.pending_decisions)}"
 
-
-def test_tick_twice():
+def test_tick_twice_with_backoff():
     pnl_tracker = Pnl(epsilon=0, backoff=10)
     pnl_tracker.tick(x=1.0, horizon=7, decision=1)
-    pnl_tracker.tick(x=1.0, horizon=7, decision=1)  # Backoff prevents tracking
-    assert(len(pnl_tracker.pending_decisions)==1)
-
+    pnl_tracker.tick(x=1.1, horizon=7, decision=1)  # Backoff prevents tracking
+    assert len(pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision, got {len(pnl_tracker.pending_decisions)}"
 
 def test_tick_twice_no_backoff():
     pnl_tracker = Pnl(epsilon=0, backoff=1)
     pnl_tracker.tick(x=1.0, horizon=7, decision=1)
-    pnl_tracker.tick(x=1.0, horizon=7, decision=1)
-    assert(len(pnl_tracker.pending_decisions)==2)
+    pnl_tracker.tick(x=1.1, horizon=7, decision=1)
+    assert len(pnl_tracker.pending_decisions) == 2, f"Expected 2 pending decisions, got {len(pnl_tracker.pending_decisions)}"
 
 def test_record_and_resolve_decision():
     """Test recording and resolving a single decision."""
     pnl_tracker = Pnl(epsilon=0)
 
-    # Step 1: Record a decision at step 0 (y = 100, decision = 1)
     pnl_tracker.tick(x=100, horizon=100, decision=1)
-    assert len(
-        pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision, got {len(pnl_tracker.pending_decisions)}"
+    assert len(pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision, got {len(pnl_tracker.pending_decisions)}"
 
-    # Step 2: Move forward 100 steps and resolve the decision (y = 150)
     pnl_tracker.current_ndx = 100
     pnl_tracker.tick(x=150, horizon=100, decision=0)  # No new decision
-    assert len(
-        pnl_tracker.pending_decisions) == 0, f"Expected 0 pending decisions after resolution, got {len(pnl_tracker.pending_decisions)}"
+    assert len(pnl_tracker.pending_decisions) == 0, f"Expected 0 pending decisions after resolution, got {len(pnl_tracker.pending_decisions)}"
     assert len(pnl_tracker.pnl_data) == 1, f"Expected 1 PnL record, got {len(pnl_tracker.pnl_data)}"
-    expected_pnl = 150 - 100 - pnl_tracker.epsilon  # PnL = y_resolution - y_decision - epsilon
-    actual_pnl = pnl_tracker.pnl_data[0][-1]
+    expected_pnl = 150 - 100 - pnl_tracker.epsilon
+    actual_pnl = pnl_tracker.pnl_data[0]['pnl']
     assert actual_pnl == expected_pnl, f"Expected PnL={expected_pnl}, got {actual_pnl}"
-
 
 def test_multiple_decisions_over_time():
     """Test multiple decisions being made and resolved over time."""
-    pnl_tracker = Pnl(epsilon=0)
 
+    pnl_tracker = Pnl(epsilon=0, backoff=0)
     # Step 1: Initial state check
     assert pnl_tracker.current_ndx == 0, f"Expected current_ndx=0, got {pnl_tracker.current_ndx}"
     assert pnl_tracker.pending_decisions == [], f"Expected pending_decisions=[], got {pnl_tracker.pending_decisions}"
     assert pnl_tracker.pnl_data == [], f"Expected pnl_data=[], got {pnl_tracker.pnl_data}"
 
+
     # Step 2: Record first decision at step 0 (y = 100, decision = 1)
     pnl_tracker.tick(x=100, horizon=100, decision=1)
-    assert len(
-        pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision, got {len(pnl_tracker.pending_decisions)}"
+    assert len(pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision, got {len(pnl_tracker.pending_decisions)}"
 
     # Step 3: Move forward by 50 steps without resolving (y = 120, decision = 0)
     pnl_tracker.current_ndx = 50
     pnl_tracker.tick(x=120, horizon=50, decision=0)
-    assert len(
-        pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision, got {len(pnl_tracker.pending_decisions)}"
+    assert len(pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision, got {len(pnl_tracker.pending_decisions)}"
 
     # Step 4: Move forward another 50 steps and resolve first decision (y = 150)
     pnl_tracker.current_ndx = 100
     pnl_tracker.tick(x=150, horizon=100, decision=0)
-    assert len(
-        pnl_tracker.pending_decisions) == 0, f"Expected 0 pending decisions after resolution, got {len(pnl_tracker.pending_decisions)}"
+    assert len(pnl_tracker.pending_decisions) == 0, f"Expected 0 pending decisions after resolution, got {len(pnl_tracker.pending_decisions)}"
     assert len(pnl_tracker.pnl_data) == 1, f"Expected 1 PnL record, got {len(pnl_tracker.pnl_data)}"
-    expected_pnl = 150 - 100 - pnl_tracker.epsilon  # PnL = y_resolution - y_decision - epsilon
-    actual_pnl = pnl_tracker.pnl_data[0][-1]
+    expected_pnl = 150 - 100 - pnl_tracker.epsilon
+    actual_pnl = pnl_tracker.pnl_data[0]['pnl']
     assert actual_pnl == expected_pnl, f"Expected PnL={expected_pnl}, got {actual_pnl}"
 
     # Step 5: Record second decision at step 100 (y = 150, decision = -1)
     pnl_tracker.tick(x=150, horizon=100, decision=-1)
-    assert len(
-        pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision, got {len(pnl_tracker.pending_decisions)}"
+    assert len(pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision, got {len(pnl_tracker.pending_decisions)}"
 
     # Step 6: Move forward 50 steps without resolving (y = 140)
     pnl_tracker.current_ndx = 150
     pnl_tracker.tick(x=140, horizon=50, decision=0)
-    assert len(
-        pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision, got {len(pnl_tracker.pending_decisions)}"
+    assert len(pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision, got {len(pnl_tracker.pending_decisions)}"
 
     # Step 7: Resolve second decision (y = 100)
-    pnl_tracker.current_ndx = 200
+    pnl_tracker.current_ndx = 201
     pnl_tracker.tick(x=130, horizon=100, decision=0)
-    assert len(
-        pnl_tracker.pending_decisions) == 0, f"Expected 0 pending decisions after resolution, got {len(pnl_tracker.pending_decisions)}"
+    assert len(pnl_tracker.pending_decisions) == 0, f"Expected 0 pending decisions after resolution, got {len(pnl_tracker.pending_decisions)}"
     assert len(pnl_tracker.pnl_data) == 2, f"Expected 2 PnL records, got {len(pnl_tracker.pnl_data)}"
 
-    # Calculate expected PnL for the second decision
-    # Decision 2: Short => PnL = y_decision - y_resolution - epsilon = 110 - 100 - 0 = 10
     expected_pnl_second = 150 - 130 - pnl_tracker.epsilon
-    actual_pnl_second = pnl_tracker.pnl_data[1][-1]
+    actual_pnl_second = pnl_tracker.pnl_data[1]['pnl']
     assert actual_pnl_second == expected_pnl_second, f"Expected second PnL={expected_pnl_second}, got {actual_pnl_second}"
-
 
 def test_sequential_decisions_and_partial_resolution():
     """Test sequential decisions and resolving them one by one."""
-    pnl_tracker = Pnl(epsilon=0)
-    pnl_tracker.backoff = 10  # Adjust backoff if necessary
+    pnl_tracker = Pnl(epsilon=0, backoff=10)
 
-    # Step 1: Record first decision
-    pnl_tracker.tick(x=100, horizon=100, decision=1)  # Decision 1: Long
-    assert len(
-        pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision, got {len(pnl_tracker.pending_decisions)}"
+    pnl_tracker.tick(x=100, horizon=100, decision=1)
+    assert len(pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision, got {len(pnl_tracker.pending_decisions)}"
 
-    # Step 2: Record second decision with a larger horizon
     pnl_tracker.current_ndx = 50
-    pnl_tracker.tick(x=110, horizon=150, decision=-1)  # Decision 2: Short (larger horizon)
-    assert len(
-        pnl_tracker.pending_decisions) == 2, f"Expected 2 pending decisions, got {len(pnl_tracker.pending_decisions)}"
+    pnl_tracker.tick(x=110, horizon=150, decision=-1)
+    assert len(pnl_tracker.pending_decisions) == 2, f"Expected 2 pending decisions, got {len(pnl_tracker.pending_decisions)}"
 
-    # Step 3: Resolve only the first decision (y = 150)
     pnl_tracker.current_ndx = 100
     pnl_tracker.tick(x=150, horizon=50, decision=0)
-    assert len(
-        pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision after partial resolution, got {len(pnl_tracker.pending_decisions)}"
+    assert len(pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision after partial resolution, got {len(pnl_tracker.pending_decisions)}"
     assert len(pnl_tracker.pnl_data) == 1, f"Expected 1 PnL record, got {len(pnl_tracker.pnl_data)}"
 
-    # Calculate expected PnL for the first decision
-    # Decision 1: Long => PnL = y_resolution - y_decision - epsilon = 150 - 100 - 0 = 50
     expected_pnl_first = 150 - 100 - pnl_tracker.epsilon
-    actual_pnl_first = pnl_tracker.pnl_data[0][-1]
+    actual_pnl_first = pnl_tracker.pnl_data[0]['pnl']
     assert actual_pnl_first == expected_pnl_first, f"Expected first PnL={expected_pnl_first}, got {actual_pnl_first}"
 
-    # Step 4: Resolve the second decision (y = 100)
     pnl_tracker.current_ndx = 200
     pnl_tracker.tick(x=100, horizon=50, decision=0)
-    assert len(
-        pnl_tracker.pending_decisions) == 0, f"Expected 0 pending decisions after full resolution, got {len(pnl_tracker.pending_decisions)}"
+    assert len(pnl_tracker.pending_decisions) == 0, f"Expected 0 pending decisions after full resolution, got {len(pnl_tracker.pending_decisions)}"
     assert len(pnl_tracker.pnl_data) == 2, f"Expected 2 PnL records, got {len(pnl_tracker.pnl_data)}"
 
-    # Calculate expected PnL for the second decision
-    # Decision 2: Short => PnL = y_decision - y_resolution - epsilon = 110 - 100 - 0 = 10
     expected_pnl_second = 110 - 100 - pnl_tracker.epsilon
-    actual_pnl_second = pnl_tracker.pnl_data[1][-1]
+    actual_pnl_second = pnl_tracker.pnl_data[1]['pnl']
     assert actual_pnl_second == expected_pnl_second, f"Expected second PnL={expected_pnl_second}, got {actual_pnl_second}"
-
 
 def test_sequential_resolutions_with_no_decision():
     """Test resolving decisions with no new decision being made."""
-    pnl_tracker = Pnl(epsilon=0)
-    pnl_tracker.backoff = 10  # Adjust backoff if necessary
+    pnl_tracker = Pnl(epsilon=0, backoff=10)
 
-    # Step 1: Record a decision (y = 100, decision = 1)
     pnl_tracker.tick(x=100, horizon=100, decision=1)
-    assert len(
-        pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision, got {len(pnl_tracker.pending_decisions)}"
+    assert len(pnl_tracker.pending_decisions) == 1, f"Expected 1 pending decision, got {len(pnl_tracker.pending_decisions)}"
 
-    # Step 2: Move forward and resolve the decision (y = 150)
     pnl_tracker.current_ndx = 100
-    pnl_tracker.tick(x=150, horizon=100, decision=0)  # No new decision
-    assert len(
-        pnl_tracker.pending_decisions) == 0, f"Expected 0 pending decisions after resolution, got {len(pnl_tracker.pending_decisions)}"
+    pnl_tracker.tick(x=150, horizon=100, decision=0)
+    assert len(pnl_tracker.pending_decisions) == 0, f"Expected 0 pending decisions after resolution, got {len(pnl_tracker.pending_decisions)}"
     assert len(pnl_tracker.pnl_data) == 1, f"Expected 1 PnL record, got {len(pnl_tracker.pnl_data)}"
-    expected_pnl = 150 - 100 - pnl_tracker.epsilon  # PnL = y_resolution - y_decision - epsilon
-    actual_pnl = pnl_tracker.pnl_data[0][-1]
+    expected_pnl = 150 - 100 - pnl_tracker.epsilon
+    actual_pnl = pnl_tracker.pnl_data[0]['pnl']
     assert actual_pnl == expected_pnl, f"Expected PnL={expected_pnl}, got {actual_pnl}"
 
-    # Step 3: Move forward with no decision (y = 160)
     pnl_tracker.current_ndx = 150
-    pnl_tracker.tick(x=160, horizon=50, decision=0)  # No new decision
-    assert len(
-        pnl_tracker.pending_decisions) == 0, f"Expected 0 pending decisions, got {len(pnl_tracker.pending_decisions)}"
+    pnl_tracker.tick(x=160, horizon=50, decision=0)
+    assert len(pnl_tracker.pending_decisions) == 0, f"Expected 0 pending decisions, got {len(pnl_tracker.pending_decisions)}"
     assert len(pnl_tracker.pnl_data) == 1, f"Expected 1 PnL record, got {len(pnl_tracker.pnl_data)}"
 
+def test_pnl_to_dict_no_backoff():
+    pnl_tracker = Pnl(epsilon=0.01, backoff=0)
+    pnl_tracker.tick(x=100, horizon=100, decision=1)
+    pnl_tracker.tick(x=150, horizon=100, decision=-1)
 
+    state = pnl_tracker.to_dict()
 
-# Running all tests using pytest
+    assert state['epsilon'] == 0.01
+    assert state['backoff'] == 0
+    assert state['current_ndx'] == 2
+    assert len(state['pending_decisions']) == 2
+    assert state['pnl_data'] == []
+
+def test_pnl_to_dict_with_backoff():
+    pnl_tracker = Pnl(epsilon=0.01, backoff=10)
+    pnl_tracker.tick(x=100, horizon=100, decision=1)
+    pnl_tracker.tick(x=150, horizon=100, decision=-1)
+
+    state = pnl_tracker.to_dict()
+
+    assert state['epsilon'] == 0.01
+    assert state['backoff'] == 10
+    assert state['current_ndx'] == 2
+    assert len(state['pending_decisions']) == 1
+    assert state['pnl_data'] == []
+
+def test_pnl_from_dict():
+    state = {
+        'epsilon': 0.01,
+        'backoff': 50,
+        'current_ndx': 2,
+        'last_attack_ndx': 1,
+        'pending_decisions': [
+            {'index': 0, 'x': 100.0, 'horizon': 100, 'decision': 1.0},
+            {'index': 1, 'x': 150.0, 'horizon': 100, 'decision': -1.0}
+        ],
+        'pnl_data': []
+    }
+
+    pnl_tracker = Pnl.from_dict(state)
+
+    assert pnl_tracker.epsilon == 0.01
+    assert pnl_tracker.backoff == 50
+    assert pnl_tracker.current_ndx == 2
+    assert pnl_tracker.last_attack_ndx == 1
+    assert len(pnl_tracker.pending_decisions) == 2
+    assert pnl_tracker.pnl_data == []
+
+def test_pnl_reset():
+    pnl_tracker = Pnl(epsilon=0.01, backoff=50)
+    pnl_tracker.tick(x=100, horizon=100, decision=1)
+    pnl_tracker.tick(x=150, horizon=100, decision=-1)
+
+    pnl_tracker.reset_pnl()
+
+    assert pnl_tracker.current_ndx == 0
+    assert pnl_tracker.last_attack_ndx is None
+    assert pnl_tracker.pending_decisions == []
+    assert pnl_tracker.pnl_data == []
+
 if __name__ == "__main__":
-    import pytest
     pytest.main([__file__])
-

--- a/tests/attackers/test_attackerwithpnl.py
+++ b/tests/attackers/test_attackerwithpnl.py
@@ -1,19 +1,14 @@
-
-# endersgame/attackers/attackerwithpnl.py
-
 # tests/attackers/test_attackerwithpnl.py
 
 import pytest
 from endersgame.attackers.attackerwithpnl import AttackerWithPnl
 from endersgame.accounting.pnl import Pnl
 from endersgame.attackers.baseattacker import BaseAttacker
-from endersgame import EPSILON
-
+from endersgame import EPSILON, DEFAULT_TRADE_BACKOFF
 
 class ConcreteAttackerWithPnl(AttackerWithPnl):
-
-    def __init__(self, epsilon: float = EPSILON):
-        super().__init__(epsilon=epsilon)
+    def __init__(self, epsilon: float = EPSILON, backoff: int = DEFAULT_TRADE_BACKOFF):
+        super().__init__(epsilon=epsilon, backoff=backoff)
 
     def tick(self, x):
         # Simple implementation for testing
@@ -23,30 +18,32 @@ class ConcreteAttackerWithPnl(AttackerWithPnl):
         # Simple implementation for testing
         return 0.0
 
-
 @pytest.fixture
 def attacker_instance():
     """
     Fixture to create an instance of ConcreteAttackerWithPnl for testing.
     """
-    return ConcreteAttackerWithPnl(epsilon=0.1)
+    return ConcreteAttackerWithPnl(epsilon=0.1, backoff=50)
 
+def test_attackerwithpnl_initialization(attacker_instance):
+    """
+    Test the initialization of AttackerWithPnl.
+    """
+    assert isinstance(attacker_instance.pnl, Pnl)
+    assert attacker_instance.pnl.epsilon == 0.1
+    assert attacker_instance.pnl.backoff == 50
 
 def test_attackerwithpnl_to_dict(attacker_instance):
     """
     Test that the to_dict method correctly serializes the AttackerWithPnl instance.
     """
-    # Simulate some ticks and predictions
-    # Since tick and predict are simple pass and return 0, pnl remains default
     state = attacker_instance.to_dict()
 
-    # Check that 'pnl' key exists
     assert 'pnl' in state
-
-    # Verify pnl serialization
     pnl_state = state['pnl']
     assert isinstance(pnl_state, dict)
     assert pnl_state['epsilon'] == 0.1
+    assert pnl_state['backoff'] == 50
     assert pnl_state['current_ndx'] == 0
     assert pnl_state['pending_decisions'] == []
     assert pnl_state['pnl_data'] == []
@@ -55,101 +52,113 @@ def test_attackerwithpnl_from_dict():
     """
     Test that the from_dict class method correctly deserializes the AttackerWithPnl instance.
     """
-    # Create a sample state dictionary
     state = {
         'pnl': {
             'epsilon': 0.2,
             'backoff': 100,
             'current_ndx': 5,
             'last_attack_ndx': 3,
-            'pending_decisions': [{'x': 100.0, 'horizon': 100, 'decision': 1.0, 'ndx': 0}],
-            'pnl_data': [{'ndx': 5, 'pnl': 50.0}]
+            'pending_decisions': [
+                {'index': 0, 'x': 100.0, 'horizon': 100, 'decision': 1.0}
+            ],
+            'pnl_data': [
+                {
+                    'decision_ndx': 5,
+                    'resolution_ndx': 10,
+                    'horizon': 100,
+                    'decision': 1.0,
+                    'y_decision': 100.0,
+                    'y_resolution': 150.0,
+                    'pnl': 50.0
+                }
+            ]
         }
     }
 
-    # Deserialize to create a new instance using the concrete subclass
     attacker = ConcreteAttackerWithPnl.from_dict(state)
 
-    # Verify the pnl attributes
     assert attacker.pnl.epsilon == 0.2
+    assert attacker.pnl.backoff == 100
     assert attacker.pnl.current_ndx == 5
-    assert attacker.pnl.pending_decisions == [{'x': 100.0, 'horizon': 100, 'decision': 1.0, 'ndx': 0}]
-    assert attacker.pnl.pnl_data == [{'ndx': 5, 'pnl': 50.0}]
-
+    assert attacker.pnl.pending_decisions == [
+        {'index': 0, 'x': 100.0, 'horizon': 100, 'decision': 1.0}
+    ]
+    assert attacker.pnl.pnl_data == [
+        {
+            'decision_ndx': 5,
+            'resolution_ndx': 10,
+            'horizon': 100,
+            'decision': 1.0,
+            'y_decision': 100.0,
+            'y_resolution': 150.0,
+            'pnl': 50.0
+        }
+    ]
 
 def test_attackerwithpnl_serialization_round_trip():
     """
     Test that serializing and then deserializing an AttackerWithPnl instance preserves its state.
     """
-    # Create an instance and simulate some state changes
-    attacker = ConcreteAttackerWithPnl(epsilon=0.3)
+    attacker = ConcreteAttackerWithPnl(epsilon=0.3, backoff=75)
     attacker.pnl.tick(x=100.0, horizon=100, decision=1.0)
     attacker.pnl.tick(x=150.0, horizon=100, decision=0.0)  # Resolves the previous decision
 
-    # Serialize to dict
     state = attacker.to_dict()
-
-    # Deserialize to create a new instance
     restored_attacker = AttackerWithPnl.from_dict(state)
 
-    # Verify that the restored attacker's pnl matches the original
     assert restored_attacker.pnl.epsilon == attacker.pnl.epsilon
+    assert restored_attacker.pnl.backoff == attacker.pnl.backoff
     assert restored_attacker.pnl.current_ndx == attacker.pnl.current_ndx
     assert restored_attacker.pnl.pending_decisions == attacker.pnl.pending_decisions
     assert restored_attacker.pnl.pnl_data == attacker.pnl.pnl_data
-
 
 def test_attackerwithpnl_from_dict_with_missing_pnl():
     """
     Test that from_dict handles missing 'pnl' key gracefully by initializing a default Pnl.
     """
-    # Create a state dictionary without 'pnl'
     state = {}
-
-    # Deserialize to create a new instance
     attacker = AttackerWithPnl.from_dict(state)
 
-    # Verify that Pnl is initialized with default epsilon
     assert attacker.pnl.epsilon == EPSILON
+    assert attacker.pnl.backoff == DEFAULT_TRADE_BACKOFF
     assert attacker.pnl.current_ndx == 0
     assert attacker.pnl.pending_decisions == []
     assert attacker.pnl.pnl_data == []
-
 
 def test_attackerwithpnl_from_dict_with_partial_pnl():
     """
     Test that from_dict handles partially missing pnl data.
     """
-    # Create a state dictionary with partial pnl data
     state = {
         'pnl': {
             'epsilon': 0.25,
-            # 'current_ndx' is missing
-            'pending_decisions': [{'x': 200.0, 'horizon': 100, 'decision': -1.0, 'ndx': 1}],
-            # 'pnl_data' is missing
+            'backoff': 80,
+            'pending_decisions': [
+                {'index': 1, 'x': 200.0, 'horizon': 100, 'decision': -1.0}
+            ],
         }
     }
 
-    # Deserialize to create a new instance
     attacker = AttackerWithPnl.from_dict(state)
 
-    # Verify the pnl attributes
     assert attacker.pnl.epsilon == 0.25
+    assert attacker.pnl.backoff == 80
     assert attacker.pnl.current_ndx == 0  # Default value
-    assert attacker.pnl.pending_decisions == [{'x': 200.0, 'horizon': 100, 'decision': -1.0, 'ndx': 1}]
+    assert attacker.pnl.pending_decisions == [
+        {'index': 1, 'x': 200.0, 'horizon': 100, 'decision': -1.0}
+    ]
     assert attacker.pnl.pnl_data == []  # Default value
-
 
 def test_attackerwithpnl_from_dict_with_malformed_pnl():
     """
     Test that from_dict raises an error or handles malformed pnl data.
     """
-    # Create a state dictionary with malformed pnl data
     state = {
         'pnl': 'this should be a dict'
     }
 
-    # Attempt to deserialize and expect an error
     with pytest.raises(AttributeError):
         AttackerWithPnl.from_dict(state)
 
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Fix matching, including horizon=1 (probably a fence/post thing)

Few notes:
- use OrderedDict for internal state of `pending_decisions` to make checks on index easier while maintaining order and not have to sort by index
- standardize serialization of PnL as `dict` so we know what the data is by looking at it